### PR TITLE
Create study session mockup

### DIFF
--- a/app/client/style.css
+++ b/app/client/style.css
@@ -41,3 +41,9 @@ footer .ui.horizontal.divider {
   height: '100vh';
   /* padding-bottom: 40px; */
 }
+
+.ui.inverted.table th {
+	background-color: #063f00 !important;
+	border-color: rgba(255, 255, 255, 0.1) !important;
+	color: rgba(255, 255, 255, 0.9) !important;
+}

--- a/app/imports/startup/server/Publications.js
+++ b/app/imports/startup/server/Publications.js
@@ -2,6 +2,14 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/alanning:roles';
 import { StudySessions } from '../../api/studysessions/StudySessions';
 
+/** This subscription publishes all documents regardless of user, but only if logged in. */
+Meteor.publish('StudySessionsAll', function publish() {
+  if (this.userId) {
+    return StudySessions.find();
+  }
+  return this.ready();
+});
+
 /** This subscription publishes only the documents associated with the logged in user */
 Meteor.publish('StudySessions', function publish() {
   if (this.userId) {

--- a/app/imports/ui/components/NavBar.jsx
+++ b/app/imports/ui/components/NavBar.jsx
@@ -28,6 +28,7 @@ class NavBar extends React.Component {
           <Menu.Item position="right" key='search'>
             <Input inverted transparent size='mini' className='icon' icon='search' placeholder='Search...'/>
           </Menu.Item>,
+          <Menu.Item as={NavLink} activeClassName="active" exact to="/allsessions" key='allsessions'>All Sessions</Menu.Item>,
           <Menu.Item as={NavLink} activeClassName="active" exact to="/sessions" key='sessions'>Sessions</Menu.Item>,
           <Menu.Item as={NavLink} activeClassName="active" exact to="/calendar" key='calendar'>Calendar</Menu.Item>,
           <Menu.Item as={NavLink} activeClassName="active" exact to="/dashboard" key='home'>Dashboard</Menu.Item>,

--- a/app/imports/ui/components/StudySession.jsx
+++ b/app/imports/ui/components/StudySession.jsx
@@ -8,14 +8,14 @@ class StudySession extends React.Component {
   render() {
     return (
         <Table.Row>
-          <Table.Cell>{this.props.studysession.course}</Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.course}</Table.Cell>
           <Table.Cell>{this.props.studysession.topic}</Table.Cell>
-          <Table.Cell>{this.props.studysession.date}</Table.Cell>
-          <Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.date}</Table.Cell>
+          <Table.Cell collapsing>
             {`${this.props.studysession.timeBegin} - ${this.props.studysession.timeEnd}`}
           </Table.Cell>
-          <Table.Cell>
-            <Link to={`/edit/${this.props.studysession._id}`}>Edit</Link>
+          <Table.Cell collapsing>
+            <Link to={`/edit/${this.props.studysession._id}`}>Edit Session</Link>
           </Table.Cell>
         </Table.Row>
     );

--- a/app/imports/ui/components/StudySessionAdmin.jsx
+++ b/app/imports/ui/components/StudySessionAdmin.jsx
@@ -7,13 +7,13 @@ class StudySessionAdmin extends React.Component {
   render() {
     return (
         <Table.Row>
-          <Table.Cell>{this.props.studysession.course}</Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.course}</Table.Cell>
           <Table.Cell>{this.props.studysession.topic}</Table.Cell>
-          <Table.Cell>{this.props.studysession.date}</Table.Cell>
-          <Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.date}</Table.Cell>
+          <Table.Cell collapsing>
             {`${this.props.studysession.timeBegin} - ${this.props.studysession.timeEnd}`}
           </Table.Cell>
-          <Table.Cell>{this.props.studysession.owner}</Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.owner}</Table.Cell>
         </Table.Row>
     );
   }

--- a/app/imports/ui/components/StudySessionAll.jsx
+++ b/app/imports/ui/components/StudySessionAll.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Table } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import { withRouter, Link } from 'react-router-dom';
+
+/** Renders a single row in the List Sessions table. See pages/ListStudySessions.jsx. */
+class StudySessionAll extends React.Component {
+  render() {
+    return (
+        <Table.Row>
+          <Table.Cell>{this.props.studysession.course}</Table.Cell>
+          <Table.Cell>{this.props.studysession.topic}</Table.Cell>
+          <Table.Cell>{this.props.studysession.date}</Table.Cell>
+          <Table.Cell>
+            {`${this.props.studysession.timeBegin} - ${this.props.studysession.timeEnd}`}
+          </Table.Cell>
+          <Table.Cell>
+            <Link to={`/join/${this.props.studysession._id}`}>Join</Link>
+          </Table.Cell>
+        </Table.Row>
+    );
+  }
+}
+
+/** Require a document to be passed to this component. */
+StudySessionAll.propTypes = {
+  studysession: PropTypes.object.isRequired,
+};
+
+/** Wrap this component in withRouter since we use the <Link> React Router element. */
+export default withRouter(StudySessionAll);

--- a/app/imports/ui/components/StudySessionAll.jsx
+++ b/app/imports/ui/components/StudySessionAll.jsx
@@ -8,14 +8,14 @@ class StudySessionAll extends React.Component {
   render() {
     return (
         <Table.Row>
-          <Table.Cell>{this.props.studysession.course}</Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.course}</Table.Cell>
           <Table.Cell>{this.props.studysession.topic}</Table.Cell>
-          <Table.Cell>{this.props.studysession.date}</Table.Cell>
-          <Table.Cell>
+          <Table.Cell collapsing>{this.props.studysession.date}</Table.Cell>
+          <Table.Cell collapsing>
             {`${this.props.studysession.timeBegin} - ${this.props.studysession.timeEnd}`}
           </Table.Cell>
-          <Table.Cell>
-            <Link to={`/join/${this.props.studysession._id}`}>Join</Link>
+          <Table.Cell collapsing>
+            <Link to={`/join/${this.props.studysession._id}`}>Join Session</Link>
           </Table.Cell>
         </Table.Row>
     );

--- a/app/imports/ui/components/react-big-calendar.css
+++ b/app/imports/ui/components/react-big-calendar.css
@@ -1,0 +1,513 @@
+@charset "UTF-8";
+.rbc-btn {
+  color: inherit;
+  font: inherit;
+  margin: 0; }
+
+button.rbc-btn {
+  overflow: visible;
+  text-transform: none;
+  -webkit-appearance: button;
+  cursor: pointer; }
+
+button[disabled].rbc-btn {
+  cursor: not-allowed; }
+
+button.rbc-input::-moz-focus-inner {
+  border: 0;
+  padding: 0; }
+
+.rbc-calendar {
+  box-sizing: border-box;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch; }
+
+.rbc-calendar *,
+.rbc-calendar *:before,
+.rbc-calendar *:after {
+  box-sizing: inherit; }
+
+.rbc-abs-full, .rbc-row-bg {
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0; }
+
+.rbc-ellipsis, .rbc-event-label, .rbc-row-segment .rbc-event-content, .rbc-show-more {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap; }
+
+.rbc-rtl {
+  direction: rtl; }
+
+.rbc-off-range {
+  color: #999999; }
+
+.rbc-off-range-bg {
+  background: #4e4e4e; }
+
+.rbc-header {
+  overflow: hidden;
+  flex: 1 0 0%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 3px;
+  text-align: center;
+  vertical-align: middle;
+  font-weight: bold;
+  font-size: 90%;
+  min-height: 0;
+  border-bottom: 1px solid #DDD; }
+  .rbc-header + .rbc-header {
+    border-left: 1px solid #DDD; }
+  .rbc-rtl .rbc-header + .rbc-header {
+    border-left-width: 0;
+    border-right: 1px solid #DDD; }
+  .rbc-header > a, .rbc-header > a:active, .rbc-header > a:visited {
+    color: inherit;
+    text-decoration: none; }
+
+.rbc-row-content {
+  position: relative;
+  user-select: none;
+  -webkit-user-select: none;
+  z-index: 4; }
+
+.rbc-today {
+  background-color: #8d8d8d; }
+
+.rbc-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px;
+  font-size: 16px; }
+  .rbc-toolbar .rbc-toolbar-label {
+    flex-grow: 1;
+    padding: 0 10px;
+    text-align: center; }
+  .rbc-toolbar button {
+    color: #373a3c;
+    display: inline-block;
+    margin: 0;
+    text-align: center;
+    vertical-align: middle;
+    background: none;
+    background-image: none;
+    border: 1px solid #ccc;
+    padding: .375rem 1rem;
+    border-radius: 4px;
+    line-height: normal;
+    white-space: nowrap; }
+    .rbc-toolbar button:active, .rbc-toolbar button.rbc-active {
+      background-image: none;
+      box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+      background-color: #e6e6e6;
+      border-color: #adadad; }
+      .rbc-toolbar button:active:hover, .rbc-toolbar button:active:focus, .rbc-toolbar button.rbc-active:hover, .rbc-toolbar button.rbc-active:focus {
+        color: #373a3c;
+        background-color: #d4d4d4;
+        border-color: #8c8c8c; }
+    .rbc-toolbar button:focus {
+      color: #373a3c;
+      background-color: #e6e6e6;
+      border-color: #adadad; }
+    .rbc-toolbar button:hover {
+      color: #373a3c;
+      background-color: #e6e6e6;
+      border-color: #adadad; }
+
+.rbc-btn-group {
+  display: inline-block;
+  white-space: nowrap; }
+  .rbc-btn-group > button:first-child:not(:last-child) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0; }
+  .rbc-btn-group > button:last-child:not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0; }
+  .rbc-rtl .rbc-btn-group > button:first-child:not(:last-child) {
+    border-radius: 4px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0; }
+  .rbc-rtl .rbc-btn-group > button:last-child:not(:first-child) {
+    border-radius: 4px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0; }
+  .rbc-btn-group > button:not(:first-child):not(:last-child) {
+    border-radius: 0; }
+  .rbc-btn-group button + button {
+    margin-left: -1px; }
+  .rbc-rtl .rbc-btn-group button + button {
+    margin-left: 0;
+    margin-right: -1px; }
+  .rbc-btn-group + .rbc-btn-group,
+  .rbc-btn-group + button {
+    margin-left: 10px; }
+
+.rbc-event {
+  border: none;
+  box-sizing: border-box;
+  box-shadow: none;
+  margin: 0;
+  padding: 2px 5px;
+  background-color: #063b00;
+  border-radius: 5px;
+  color: #fff;
+  cursor: pointer;
+  width: 100%;
+  text-align: left; }
+  .rbc-slot-selecting .rbc-event {
+    cursor: inherit;
+    pointer-events: none; }
+  .rbc-event.rbc-selected {
+    background-color: #085300; }
+  .rbc-event:focus {
+    outline: 5px auto #3b99fc; }
+
+.rbc-event-label {
+  font-size: 80%; }
+
+.rbc-event-overlaps {
+  box-shadow: -1px 1px 5px 0px rgba(51, 51, 51, 0.5); }
+
+.rbc-event-continues-prior {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0; }
+
+.rbc-event-continues-after {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0; }
+
+.rbc-event-continues-earlier {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0; }
+
+.rbc-event-continues-later {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0; }
+
+.rbc-row {
+  display: flex;
+  flex-direction: row; }
+
+.rbc-row-segment {
+  padding: 0 1px 1px 1px; }
+
+.rbc-selected-cell {
+  background-color: rgba(0, 0, 0, 0.1); }
+
+.rbc-show-more {
+  background-color: rgba(255, 255, 255, 0.3);
+  z-index: 4;
+  font-weight: bold;
+  font-size: 85%;
+  height: auto;
+  line-height: normal; }
+
+.rbc-month-view {
+  position: relative;
+  border: 1px solid #DDD;
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  width: 100%;
+  user-select: none;
+  -webkit-user-select: none;
+  height: 100%; }
+
+.rbc-month-header {
+  display: flex;
+  flex-direction: row; }
+
+.rbc-month-row {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  flex: 1 0 0;
+  flex-basis: 0px;
+  overflow: hidden;
+  height: 100%; }
+  .rbc-month-row + .rbc-month-row {
+    border-top: 1px solid #DDD; }
+
+.rbc-date-cell {
+  flex: 1 1 0;
+  min-width: 0;
+  padding-right: 5px;
+  text-align: right; }
+  .rbc-date-cell.rbc-now {
+    font-weight: bold; }
+  .rbc-date-cell > a, .rbc-date-cell > a:active, .rbc-date-cell > a:visited {
+    color: inherit;
+    text-decoration: none; }
+
+.rbc-row-bg {
+  display: flex;
+  flex-direction: row;
+  flex: 1 0 0;
+  overflow: hidden; }
+
+.rbc-day-bg {
+  flex: 1 0 0%; }
+  .rbc-day-bg + .rbc-day-bg {
+    border-left: 1px solid #DDD; }
+  .rbc-rtl .rbc-day-bg + .rbc-day-bg {
+    border-left-width: 0;
+    border-right: 1px solid #DDD; }
+
+.rbc-overlay {
+  position: absolute;
+  z-index: 5;
+  border: 1px solid #e5e5e5;
+  background-color: #fff;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.25);
+  padding: 10px; }
+  .rbc-overlay > * + * {
+    margin-top: 1px; }
+
+.rbc-overlay-header {
+  border-bottom: 1px solid #e5e5e5;
+  margin: -10px -10px 5px -10px;
+  padding: 2px 10px; }
+
+.rbc-agenda-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  overflow: auto; }
+  .rbc-agenda-view table.rbc-agenda-table {
+    width: 100%;
+    border: 1px solid #DDD;
+    border-spacing: 0;
+    border-collapse: collapse; }
+    .rbc-agenda-view table.rbc-agenda-table tbody > tr > td {
+      padding: 5px 10px;
+      vertical-align: top; }
+    .rbc-agenda-view table.rbc-agenda-table .rbc-agenda-time-cell {
+      padding-left: 15px;
+      padding-right: 15px;
+      text-transform: lowercase; }
+    .rbc-agenda-view table.rbc-agenda-table tbody > tr > td + td {
+      border-left: 1px solid #DDD; }
+    .rbc-rtl .rbc-agenda-view table.rbc-agenda-table tbody > tr > td + td {
+      border-left-width: 0;
+      border-right: 1px solid #DDD; }
+    .rbc-agenda-view table.rbc-agenda-table tbody > tr + tr {
+      border-top: 1px solid #DDD; }
+    .rbc-agenda-view table.rbc-agenda-table thead > tr > th {
+      padding: 3px 5px;
+      text-align: left;
+      border-bottom: 1px solid #DDD; }
+      .rbc-rtl .rbc-agenda-view table.rbc-agenda-table thead > tr > th {
+        text-align: right; }
+
+.rbc-agenda-time-cell {
+  text-transform: lowercase; }
+  .rbc-agenda-time-cell .rbc-continues-after:after {
+    content: ' »'; }
+  .rbc-agenda-time-cell .rbc-continues-prior:before {
+    content: '« '; }
+
+.rbc-agenda-date-cell,
+.rbc-agenda-time-cell {
+  white-space: nowrap; }
+
+.rbc-agenda-event-cell {
+  width: 100%; }
+
+.rbc-time-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%; }
+  .rbc-time-column .rbc-timeslot-group {
+    flex: 1; }
+
+.rbc-timeslot-group {
+  border-bottom: 1px solid #DDD;
+  min-height: 40px;
+  display: flex;
+  flex-flow: column nowrap; }
+
+.rbc-time-gutter,
+.rbc-header-gutter {
+  flex: none; }
+
+.rbc-label {
+  padding: 0 5px; }
+
+.rbc-day-slot {
+  position: relative; }
+  .rbc-day-slot .rbc-events-container {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    margin-right: 10px;
+    top: 0; }
+    .rbc-day-slot .rbc-events-container.rbc-rtl {
+      left: 10px;
+      right: 0; }
+  .rbc-day-slot .rbc-event {
+    border: 1px solid #265985;
+    display: flex;
+    max-height: 100%;
+    min-height: 20px;
+    flex-flow: column wrap;
+    align-items: flex-start;
+    overflow: hidden;
+    position: absolute; }
+  .rbc-day-slot .rbc-event-label {
+    flex: none;
+    padding-right: 5px;
+    width: auto; }
+  .rbc-day-slot .rbc-event-content {
+    width: 100%;
+    flex: 1 1 0;
+    word-wrap: break-word;
+    line-height: 1;
+    height: 100%;
+    min-height: 1em; }
+  .rbc-day-slot .rbc-time-slot {
+    border-top: 1px solid #f7f7f7; }
+
+.rbc-time-view-resources .rbc-time-gutter,
+.rbc-time-view-resources .rbc-time-header-gutter {
+  position: sticky;
+  left: 0;
+  background-color: white;
+  border-right: 1px solid #DDD;
+  z-index: 10;
+  margin-right: -1px; }
+
+.rbc-time-view-resources .rbc-time-header {
+  overflow: hidden; }
+
+.rbc-time-view-resources .rbc-time-header-content {
+  min-width: auto;
+  flex: 1 0 0;
+  flex-basis: 0px; }
+
+.rbc-time-view-resources .rbc-time-header-cell-single-day {
+  display: none; }
+
+.rbc-time-view-resources .rbc-day-slot {
+  min-width: 140px; }
+
+.rbc-time-view-resources .rbc-header,
+.rbc-time-view-resources .rbc-day-bg {
+  width: 140px;
+  flex: 1 1 0;
+  flex-basis: 0 px; }
+
+.rbc-time-header-content + .rbc-time-header-content {
+  margin-left: -1px; }
+
+.rbc-time-slot {
+  flex: 1 0 0; }
+  .rbc-time-slot.rbc-now {
+    font-weight: bold; }
+
+.rbc-day-header {
+  text-align: center; }
+
+.rbc-slot-selection {
+  z-index: 10;
+  position: absolute;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  font-size: 75%;
+  width: 100%;
+  padding: 3px; }
+
+.rbc-slot-selecting {
+  cursor: move; }
+
+.rbc-time-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 100%;
+  border: 1px solid #DDD;
+  min-height: 0; }
+  .rbc-time-view .rbc-time-gutter {
+    white-space: nowrap; }
+  .rbc-time-view .rbc-allday-cell {
+    box-sizing: content-box;
+    width: 100%;
+    height: 100%;
+    position: relative; }
+  .rbc-time-view .rbc-allday-cell + .rbc-allday-cell {
+    border-left: 1px solid #DDD; }
+  .rbc-time-view .rbc-allday-events {
+    position: relative;
+    z-index: 4; }
+  .rbc-time-view .rbc-row {
+    box-sizing: border-box;
+    min-height: 20px; }
+
+.rbc-time-header {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: row; }
+  .rbc-time-header.rbc-overflowing {
+    border-right: 1px solid #DDD; }
+  .rbc-rtl .rbc-time-header.rbc-overflowing {
+    border-right-width: 0;
+    border-left: 1px solid #DDD; }
+  .rbc-time-header > .rbc-row:first-child {
+    border-bottom: 1px solid #DDD; }
+  .rbc-time-header > .rbc-row.rbc-row-resource {
+    border-bottom: 1px solid #DDD; }
+
+.rbc-time-header-cell-single-day {
+  display: none; }
+
+.rbc-time-header-content {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  border-left: 1px solid #DDD; }
+  .rbc-rtl .rbc-time-header-content {
+    border-left-width: 0;
+    border-right: 1px solid #DDD; }
+  .rbc-time-header-content > .rbc-row.rbc-row-resource {
+    border-bottom: 1px solid #DDD;
+    flex-shrink: 0; }
+
+.rbc-time-content {
+  display: flex;
+  flex: 1 0 0%;
+  align-items: flex-start;
+  width: 100%;
+  border-top: 2px solid #DDD;
+  overflow-y: auto;
+  position: relative; }
+  .rbc-time-content > .rbc-time-gutter {
+    flex: none; }
+  .rbc-time-content > * + * > * {
+    border-left: 1px solid #DDD; }
+  .rbc-rtl .rbc-time-content > * + * > * {
+    border-left-width: 0;
+    border-right: 1px solid #DDD; }
+  .rbc-time-content > .rbc-day-slot {
+    width: 100%;
+    user-select: none;
+    -webkit-user-select: none; }
+
+.rbc-current-time-indicator {
+  position: absolute;
+  z-index: 3;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background-color: #74ad31;
+  pointer-events: none; }

--- a/app/imports/ui/layouts/App.jsx
+++ b/app/imports/ui/layouts/App.jsx
@@ -7,6 +7,7 @@ import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom'
 import NavBar from '../components/NavBar';
 import Footer from '../components/Footer';
 import Landing from '../pages/Landing';
+import ListStudySessionsAll from '../pages/ListStudySessionsAll';
 import ListStudySessions from '../pages/ListStudySessions';
 import ListStudySessionsAdmin from '../pages/ListStudySessionsAdmin';
 import AddStudySession from '../pages/AddStudySession';
@@ -31,6 +32,7 @@ class App extends React.Component {
               <SignInSignUpRoute path="/signin" component={Signin}/>
               <SignInSignUpRoute path="/signup" component={Signup}/>
               <ProtectedRoute path="/dashboard" component={Dashboard}/>
+              <ProtectedRoute path="/allsessions" component={ListStudySessionsAll}/>
               <ProtectedRoute path="/sessions" component={ListStudySessions}/>
               <ProtectedRoute path="/add" component={AddStudySession}/>
               <ProtectedRoute path="/calendar" component={Calendar}/>

--- a/app/imports/ui/pages/AddStudySession.jsx
+++ b/app/imports/ui/pages/AddStudySession.jsx
@@ -45,18 +45,20 @@ class AddStudySession extends React.Component {
     return (
         <Grid container centered className="main-content">
           <Grid.Column>
-            <Header as="h2" textAlign="center">Add Session</Header>
-            <AutoForm ref={ref => { fRef = ref; }} schema={formSchema} onSubmit={data => this.submit(data, fRef)} >
-              <Segment>
-                <TextField name='course' placeholder="ICS311"/>
-                <TextField name='topic' placeholder="Binary Search Trees"/>
-                <TextField name='date' placeholder="03/15/2020"/>
-                <TextField name='timeBegin' placeholder="0900"/>
-                <TextField name='timeEnd' placeholder="1000"/>
-                <SubmitField value='Submit'/>
-                <ErrorsField/>
-              </Segment>
-            </AutoForm>
+            <div style={{ width: '400px', marginLeft: 'auto', marginRight: 'auto' }}>
+              <Header as="h2" textAlign="center">Add Session</Header>
+              <AutoForm ref={ref => { fRef = ref; }} schema={formSchema} onSubmit={data => this.submit(data, fRef)} >
+                <Segment inverted>
+                  <TextField name='course' placeholder="ICS311"/>
+                  <TextField name='topic' placeholder="Binary Search Trees"/>
+                  <TextField name='date' placeholder="03/15/2020"/>
+                  <TextField name='timeBegin' placeholder="0900"/>
+                  <TextField name='timeEnd' placeholder="1000"/>
+                  <SubmitField value='Submit'/>
+                  <ErrorsField/>
+                </Segment>
+              </AutoForm>
+            </div>
           </Grid.Column>
         </Grid>
     );

--- a/app/imports/ui/pages/AddStudySession.jsx
+++ b/app/imports/ui/pages/AddStudySession.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Grid, Segment, Header } from 'semantic-ui-react';
 import { AutoForm, ErrorsField, SubmitField, TextField } from 'uniforms-semantic';
 import Swal from 'sweetalert2';
+import '@sweetalert2/theme-dark/dark.css';
 import { Meteor } from 'meteor/meteor';
 import 'uniforms-bridge-simple-schema-2'; // required for Uniforms
 import SimpleSchema from 'simpl-schema';

--- a/app/imports/ui/pages/Calendar.jsx
+++ b/app/imports/ui/pages/Calendar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Grid, Header } from 'semantic-ui-react';
 import Swal from 'sweetalert2';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
+import '../components/react-big-calendar.css';
 import { Calendar as Cal, momentLocalizer } from 'react-big-calendar';
 import moment from 'moment';
 import events from '../components/events';

--- a/app/imports/ui/pages/ListStudySessions.jsx
+++ b/app/imports/ui/pages/ListStudySessions.jsx
@@ -21,14 +21,14 @@ class ListStudySessions extends React.Component {
         <Grid container centered className="main-content">
           <Grid.Column>
             <Header as="h2" textAlign="center">List Sessions</Header>
-            <Table celled>
+            <Table celled inverted compact>
               <Table.Header>
                 <Table.Row>
                   <Table.HeaderCell>Course</Table.HeaderCell>
                   <Table.HeaderCell>Topic</Table.HeaderCell>
                   <Table.HeaderCell>Date</Table.HeaderCell>
                   <Table.HeaderCell>Time</Table.HeaderCell>
-                  <Table.HeaderCell>Edit</Table.HeaderCell>
+                  <Table.HeaderCell></Table.HeaderCell>
                 </Table.Row>
               </Table.Header>
               <Table.Body>
@@ -36,7 +36,7 @@ class ListStudySessions extends React.Component {
                   key={studysession._id} studysession={studysession} />)}
               </Table.Body>
             </Table>
-            <Button as={NavLink} activeClassName="active" exact to="/add" key='add'>Create Session</Button>
+            <Button compact secondary as={NavLink} activeClassName="active" exact to="/add" key='add'>Create Session</Button>
           </Grid.Column>
         </Grid>
     );

--- a/app/imports/ui/pages/ListStudySessionsAdmin.jsx
+++ b/app/imports/ui/pages/ListStudySessionsAdmin.jsx
@@ -20,7 +20,7 @@ class ListStudySessionsAdmin extends React.Component {
         <Grid container centered className="main-content">
           <Grid.Column>
             <Header as="h2" textAlign="center">List Sessions (Admin)</Header>
-            <Table celled>
+            <Table celled inverted compact>
               <Table.Header>
                 <Table.Row>
                   <Table.HeaderCell>Course</Table.HeaderCell>

--- a/app/imports/ui/pages/ListStudySessionsAll.jsx
+++ b/app/imports/ui/pages/ListStudySessionsAll.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Meteor } from 'meteor/meteor';
+import { Grid, Table, Header, Loader, Button } from 'semantic-ui-react';
+import { withTracker } from 'meteor/react-meteor-data';
+import { NavLink } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { StudySessions } from '../../api/studysessions/StudySessions';
+import StudySessionAll from '../components/StudySessionAll';
+
+/** Renders a table containing all of the StudySessions. Use <StudySession> to render each row. */
+class ListStudySessionsAll extends React.Component {
+
+  /** If the subscription(s) have been received, render the page, otherwise show a loading icon. */
+  render() {
+    return (this.props.ready) ? this.renderPage() : <Loader active>Getting data</Loader>;
+  }
+
+  /** Render the page once subscriptions have been received. */
+  renderPage() {
+    return (
+        <Grid container centered className="main-content">
+          <Grid.Column>
+            <Header as="h2" textAlign="center">List Sessions (All)</Header>
+            <Table celled>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>Course</Table.HeaderCell>
+                  <Table.HeaderCell>Topic</Table.HeaderCell>
+                  <Table.HeaderCell>Date</Table.HeaderCell>
+                  <Table.HeaderCell>Time</Table.HeaderCell>
+                  <Table.HeaderCell></Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {this.props.studysessions.map((studysession) => <StudySessionAll
+                  key={studysession._id} studysession={studysession} />)}
+              </Table.Body>
+            </Table>
+            <Button as={NavLink} activeClassName="active" exact to="/add" key='add'>Create Session</Button>
+          </Grid.Column>
+        </Grid>
+    );
+  }
+}
+
+/** Require an array of StudySessions in the props. */
+ListStudySessionsAll.propTypes = {
+  studysessions: PropTypes.array.isRequired,
+  ready: PropTypes.bool.isRequired,
+};
+
+/** withTracker connects Meteor data to React components. https://guide.meteor.com/react.html#using-withTracker */
+export default withTracker(() => {
+  // Get access to Sessions.
+  const subscription = Meteor.subscribe('StudySessionsAll');
+  return {
+    studysessions: StudySessions.find({}).fetch(),
+    ready: subscription.ready(),
+  };
+})(ListStudySessionsAll);

--- a/app/imports/ui/pages/ListStudySessionsAll.jsx
+++ b/app/imports/ui/pages/ListStudySessionsAll.jsx
@@ -21,7 +21,7 @@ class ListStudySessionsAll extends React.Component {
         <Grid container centered className="main-content">
           <Grid.Column>
             <Header as="h2" textAlign="center">List Sessions (All)</Header>
-            <Table celled>
+            <Table celled inverted compact>
               <Table.Header>
                 <Table.Row>
                   <Table.HeaderCell>Course</Table.HeaderCell>
@@ -36,7 +36,7 @@ class ListStudySessionsAll extends React.Component {
                   key={studysession._id} studysession={studysession} />)}
               </Table.Body>
             </Table>
-            <Button as={NavLink} activeClassName="active" exact to="/add" key='add'>Create Session</Button>
+            <Button compact secondary as={NavLink} activeClassName="active" exact to="/add" key='add'>Create Session</Button>
           </Grid.Column>
         </Grid>
     );

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -169,6 +169,11 @@
         "react-is": "^16.6.3"
       }
     },
+    "@sweetalert2/theme-dark": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@sweetalert2/theme-dark/-/theme-dark-3.1.4.tgz",
+      "integrity": "sha512-JiFqylrr7bKw1WSxyu7KmaIUq9iV7C1PD1Paaaxpvr1Bs4mK+lFJrV5TaGEECcke0wkV1koDyxBZllE7V7tRJg=="
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@babel/runtime": "^7.8.3",
+    "@sweetalert2/theme-dark": "^3.1.4",
     "classnames": "^2.2.6",
     "core-js": "^3.6.4",
     "graphql": "^14.5.8",


### PR DESCRIPTION
Bulk of the work for #13 done.

- The basic study session page is mocked up
- List all the currently scheduled sessions (not just your own)
- Has a link to "join" the session (does not work yet)
- Create session button (still need to differentiate between a right now and future session)
- Create session page is mocked up (and also works if you follow the given format)
- Style changes
  - Dark background/tables/forms
  - Green headers
  - Dark buttons
  - Dark calendar (this is a bit of a hack, uses a local copy of the stylesheet now)
  - Swal popups are dark theme now too